### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the current directory contents into the container at /app
+COPY . /app
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Make port 80 available to the world outside this container
+EXPOSE 80
+
+# Define environment variable
+ENV NAME World
+
+# Run app.py when the container launches
+CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -46,3 +46,33 @@ Check a full list of supported models at `src/llm_client/llm_model.py`.
     - gemma-7b-it
  - [Together](https://docs.together.ai/docs/function-calling#supported-models): 
     - mistralai/Mixtral-8x7B-Instruct-v0.1  
+
+## Docker Support
+
+### Building the Docker Image
+
+To build the Docker image for mini-agent, run the following command in the project root directory:
+
+```bash
+docker build -t mini-agent .
+```
+
+### Running the mini-agent in a Docker Container
+
+After building the image, you can run the mini-agent in a Docker container using:
+
+```bash
+docker run -it --env-file .env mini-agent
+```
+
+Note: Make sure your `.env` file is properly configured with the necessary API keys before running the container.
+
+### Development with Docker
+
+For development purposes, you can mount your local directory to the container:
+
+```bash
+docker run -it --env-file .env -v $(pwd):/app mini-agent
+```
+
+This allows you to make changes to the code on your host machine and have them reflected in the container.


### PR DESCRIPTION
This PR adds initial Docker support to the mini-agent project. It includes:

- A basic Dockerfile for building the mini-agent image
- Updated README with Docker build and run instructions

This is an initial implementation and may require further refinement and testing.